### PR TITLE
Fix docblock for static analysis

### DIFF
--- a/src/Distance.php
+++ b/src/Distance.php
@@ -15,10 +15,10 @@ class Distance
      * Get distance between two coordinates
      *
      * @return float
-     * @param  decimal $latitude1
-     * @param  decimal $longitude1
-     * @param  decimal $latitude2
-     * @param  decimal $longitude2
+     * @param  float   $latitude1
+     * @param  float   $longitude1
+     * @param  float   $latitude2
+     * @param  float   $longitude2
      * @param  int     $decimals[optional] The amount of decimals
      * @param  string  $unit[optional]
      */
@@ -53,8 +53,8 @@ class Distance
      * Get closest location from all locations
      *
      * @return array   The item which is the closest + 'distance' to it.
-     * @param  decimal $latitude1
-     * @param  decimal $longitude1
+     * @param  float   $latitude1
+     * @param  float   $longitude1
      * @param  array   $items = array(array('latitude' => 'x', 'longitude' => 'x'), array(xxx))
      * @param  int     $decimals[optional] The amount of decimals
      * @param  string  $unit[optional]


### PR DESCRIPTION
Defines the lat/lng in the docblocks as `float`. Using decimal returns the following when running `phpstan`:

```
  29     Parameter #1 $latitude1 of static method JeroenDesloovere\Distance\Distance::between() expects JeroenDesloovere\Distance\decimal, float given.
  30     Parameter #2 $longitude1 of static method JeroenDesloovere\Distance\Distance::between() expects JeroenDesloovere\Distance\decimal, float given.
  31     Parameter #3 $latitude2 of static method JeroenDesloovere\Distance\Distance::between() expects JeroenDesloovere\Distance\decimal, float given.
  32     Parameter #4 $longitude2 of static method JeroenDesloovere\Distance\Distance::between() expects JeroenDesloovere\Distance\decimal, float given.
```